### PR TITLE
eels: optionally consume pre-staged local fixtures

### DIFF
--- a/simulators/ethereum/eels/consume-engine/Dockerfile
+++ b/simulators/ethereum/eels/consume-engine/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume engine simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -18,12 +18,26 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/packages/testing
+RUN uv sync
+
+# Optionally bake pre-staged fixtures into the image so `consume` reads them
+# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
+# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
+# release/URL and consume downloads as before. Extraction runs in a throwaway
+# stage so the tarball never lands in the final image (no size doubling); the
+# `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
+FROM base AS fixtures-stage
+COPY Dockerfile fixtures.tar.gz* /staged/
+RUN mkdir -p /fixtures && \
+    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
+
+FROM base
+COPY --from=fixtures-stage /fixtures /fixtures
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
-RUN uv sync
 RUN uv run consume cache --input "$FIXTURES"
 
 

--- a/simulators/ethereum/eels/consume-rlp/Dockerfile
+++ b/simulators/ethereum/eels/consume-rlp/Dockerfile
@@ -1,5 +1,5 @@
 # Builds and runs the EELS (execution-specs) consume rlp simulator
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS base
 
 ## Default fixtures/git-ref
 ARG fixtures=stable@latest
@@ -18,13 +18,27 @@ RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && \
     fi
 
 WORKDIR /execution-specs/packages/testing
+RUN uv sync
+
+# Optionally bake pre-staged fixtures into the image so `consume` reads them
+# locally instead of downloading. A caller that stages ./fixtures.tar.gz and
+# passes fixtures=/fixtures gets the local fixtures; otherwise FIXTURES stays a
+# release/URL and consume downloads as before. Extraction runs in a throwaway
+# stage so the tarball never lands in the final image (no size doubling); the
+# `Dockerfile` anchor keeps COPY from failing when no tarball is staged.
+FROM base AS fixtures-stage
+COPY Dockerfile fixtures.tar.gz* /staged/
+RUN mkdir -p /fixtures && \
+    if [ -f /staged/fixtures.tar.gz ]; then tar -xzf /staged/fixtures.tar.gz -C /fixtures; fi
+
+FROM base
+COPY --from=fixtures-stage /fixtures /fixtures
 
 # Cache the fixtures. This is done to avoid re-downloading the fixtures every time
 # the container starts.
 # If newer version of the fixtures is needed, the image needs to be rebuilt.
 # Use `--docker.nocache` flag to force rebuild.
 RUN uv run consume cache --input "$FIXTURES"
-RUN uv sync
 
 ## Define `consume rlp` entry point using the local fixtures
 ENTRYPOINT uv run consume rlp -v --input "$FIXTURES"


### PR DESCRIPTION
## Why

The `eels/consume-engine` and `eels/consume-rlp` simulators download the fixtures tarball at **image-build time** via `uv run consume cache --input "$FIXTURES"`. Because hive is invoked with `--docker.nocache`, that download repeats on **every run**, which is slow and exposed to transient GitHub release-CDN failures (e.g. HTTP 504s).

## What

Let a caller provide the fixtures **locally** instead of by URL:

- Stage a `fixtures.tar.gz` into the simulator build context and pass `--build-arg fixtures=/fixtures`.
- The tarball is extracted in a **throwaway build stage**; only the extracted directory is `COPY --from`'d into the final image, so the tarball never lands in the final image (no size doubling).
- `consume` then reads `--input /fixtures` (a local directory), which it accepts and recursively indexes — verified against `execution-specs`/`consume` (`FixturesSource.validate_local_path` + `generate_fixtures_index`).

## Backward compatible

With **no** `fixtures.tar.gz` staged and `fixtures=<release/url>` (the default, and how it's invoked today), the optional `COPY` matches only the `Dockerfile` anchor, `/fixtures` stays empty, `FIXTURES` remains the URL/release, and `consume` downloads exactly as before. The new path activates only when both a tarball is staged and `fixtures=/fixtures` is passed.

## Consumer

This unblocks erigon's `test-hive-eest.yml` to restore the fixtures from its existing `actions/cache` (warmed out-of-band) and pass them in locally, removing the per-run CDN download. Only `consume-engine` and `consume-rlp` are changed (the two simulators erigon's matrix uses); the other `eels` simulators are untouched and can adopt the same pattern later if needed.
